### PR TITLE
Temporary Fix for Grenadier and some other related stuff

### DIFF
--- a/mods/tdo/rules/weapons.yaml
+++ b/mods/tdo/rules/weapons.yaml
@@ -211,11 +211,11 @@ Grenade:
 	Projectile: Bullet
 		Speed: 140
 		Blockable: false
-		LaunchAngle: 62
-		Inaccuracy: 813
+		LaunchAngle: 92
+		Inaccuracy: 600
 		Image: BOMB
 	Warhead@1Dam: SpreadDamage
-		Spread: 6
+		Spread: 128
 		Damage: 50
 		Versus:
 			0: 87


### PR DESCRIPTION
Changes spalsh damage from 6 into 128.
NOTE: 6 is the value taken as it is from the original game.

Changes inaccuracy from 813 into 600 as it was too inaccurate vs the original game.

Also Changes LaunchAngle into 92 from 62 as a visual change.

NOTE: This is not fully tested with the original game, further tests are adviced.

Closes #87