### PR TITLE
General Air Update WIP

### DIFF
--- a/mods/tdo/dedicated_server_options.yaml
+++ b/mods/tdo/dedicated_server_options.yaml
@@ -104,6 +104,6 @@ Player:
 		Locked: False
 			#can the admin player change this?
 	LobbyPrerequisiteCheckbox@EMPTYHELIPADS:
-		Description: Build empty helipads that cost $300 
-		Enabled: False
+		Description: Placed helipads spawn aircraft but they cost $1500
+		Enabled: True
 		Locked: False

--- a/mods/tdo/dedicated_server_options.yaml
+++ b/mods/tdo/dedicated_server_options.yaml
@@ -103,3 +103,7 @@ Player:
 		Enabled: True
 		Locked: False
 			#can the admin player change this?
+	LobbyPrerequisiteCheckbox@EMPTYHELIPADS:
+		Description: Build empty helipads that cost $300 
+		Enabled: False
+		Locked: False

--- a/mods/tdo/rules/lobby_options.yaml
+++ b/mods/tdo/rules/lobby_options.yaml
@@ -347,6 +347,15 @@ Player:
 		Visible: True
 		DisplayOrder: 10
 		Prerequisites: RegrowthOn
+	LobbyPrerequisiteCheckbox@EMPTYHELIPADS:
+		ID: emptypads
+		Label: Empty Helipads
+		Description: Build empty helipads that cost $300 
+		Enabled: False
+		Locked: False
+		Visible: True
+		DisplayOrder: 10
+		Prerequisites: emptyhelipads
 #	#waiting for this https://github.com/OpenRA/OpenRA/issues/18040
 #	# LobbyPrerequisiteCheckbox@LOWCOSTMCV:
 #		# ID: lowcostmcv

--- a/mods/tdo/rules/lobby_options.yaml
+++ b/mods/tdo/rules/lobby_options.yaml
@@ -349,9 +349,9 @@ Player:
 		Prerequisites: RegrowthOn
 	LobbyPrerequisiteCheckbox@EMPTYHELIPADS:
 		ID: emptypads
-		Label: Empty Helipads
-		Description: Build empty helipads that cost $300 
-		Enabled: False
+		Label: Helipad With Aircraft
+		Description: Placed helipads spawn aircraft but they cost $1500
+		Enabled: True
 		Locked: False
 		Visible: True
 		DisplayOrder: 10

--- a/mods/tdo/rules/structures.yaml
+++ b/mods/tdo/rules/structures.yaml
@@ -538,7 +538,7 @@ HPAD:
 		Cost: 1500
 	ProductionCostMultiplier:
 		Multiplier: 20
-		Prerequisites: emptyhelipads
+		Prerequisites: !emptyhelipads
 	GrantConditionOnPrerequisite@EMPTYHELIPADS:
 		Prerequisites: emptyhelipads
 		Condition: ConEmptyHelipads
@@ -574,12 +574,12 @@ HPAD:
 		Actor: heli
 		Facing: 224
 		SpawnOffset: 0,0
-		RequiresCondition: NodHelipad && !ConEmptyHelipads
+		RequiresCondition: NodHelipad && ConEmptyHelipads && !build-incomplete
 	FreeActor@Orca:
 		Actor: orca
 		Facing: 224
 		SpawnOffset: 0,0
-		RequiresCondition: GDIHelipad && !ConEmptyHelipads
+		RequiresCondition: GDIHelipad && ConEmptyHelipads && !build-incomplete
 	Building:
 		Footprint: xx xx ==
 		Dimensions: 2,3
@@ -594,8 +594,14 @@ HPAD:
 	Exit@1:
 		SpawnOffset: 0,-256,0
 		ProductionTypes: Aircraft
-	ProductionFromMapEdge:
+	ExternalCondition@OCCUPIEDSTATUS:
+		Condition: occupied
+	ProductionFromMapEdge@UNOCCUPIED:
 		Produces: Aircraft
+		PauseOnCondition: !occupied 
+	Production@OCCUPIED:
+		Produces: Aircraft
+		PauseOnCondition: occupied
 	Reservable:
 	WithResupplyAnimation:
 		RequiresCondition: !build-incomplete

--- a/mods/tdo/rules/structures.yaml
+++ b/mods/tdo/rules/structures.yaml
@@ -536,10 +536,14 @@ HPAD:
 		TargetableOffsets: 0,0,0, 768,-512,0, 768,512,0, -281,-512,0, -630,512,0
 	Valued:
 		Cost: 1500
+	ProductionCostMultiplier:
+		Multiplier: 20
+		Prerequisites: emptyhelipads
+	GrantConditionOnPrerequisite@EMPTYHELIPADS:
+		Prerequisites: emptyhelipads
+		Condition: ConEmptyHelipads
 	PrimaryBuilding:
 		ProductionQueues: Aircraft
-	#Valued:
-	#	Cost: 300
 	Tooltip:
 		Name: Helipad
 	Buildable:
@@ -547,6 +551,7 @@ HPAD:
 		Prerequisites: ~barracks, ~tl6
 		Queue: Building
 		Description: Produces and rearms helicopters
+		BuildDuration: 300
 	ProductionBar:
 		ProductionType: Aircraft
 		Color: 00FFDF
@@ -569,12 +574,12 @@ HPAD:
 		Actor: heli
 		Facing: 224
 		SpawnOffset: 0,0
-		RequiresCondition: NodHelipad
+		RequiresCondition: NodHelipad && !ConEmptyHelipads
 	FreeActor@Orca:
 		Actor: orca
 		Facing: 224
 		SpawnOffset: 0,0
-		RequiresCondition: GDIHelipad
+		RequiresCondition: GDIHelipad && !ConEmptyHelipads
 	Building:
 		Footprint: xx xx ==
 		Dimensions: 2,3

--- a/mods/tdo/rules/system.yaml
+++ b/mods/tdo/rules/system.yaml
@@ -626,6 +626,12 @@ Player:
 	Sellable:
 		RefundPercent: 30
 		RequiresCondition: OnPad && !airborne || NearWall && !airborne
+	ProximityExternalCondition@ONHELIPAD:
+		Condition: occupied
+		Range: 1c0
+		ValidStances: Ally
+		AffectsParent: False
+		RequiresCondition: !airborne
 	ProximityExternalCondition@REPAIRING:
 		Condition: Repairing
 		Range: 1c0
@@ -665,6 +671,8 @@ Player:
 		IdleBehavior: Land
 		Crushes: crate
 		LandableTerrainTypes: Clear,Rough,Road,Ore,Beach,Tiberium,BlueTiberium
+		TurnToDock: True
+		TurnToLand: True
 	HiddenUnderFog:
 		Type: GroundPosition
 	ActorLostNotification:

--- a/mods/tdo/rules/units.yaml
+++ b/mods/tdo/rules/units.yaml
@@ -1059,7 +1059,6 @@ TRAN:
 		Prerequisites: ~hpad, ~tl6
 		Description: Fast Infantry Transport Helicopter.\n  Unarmed
 	Aircraft:
-		TurnToLand: True
 		InitialFacing: 1
 		TurnSpeed: 5
 		Speed: 90
@@ -1116,6 +1115,7 @@ HELI:
 	Aircraft:
 		TurnSpeed: 4
 		Speed: 120
+		InitialFacing: 224
 	Rearmable:
 		RearmActors: hpad
 		AmmoPools: primary, secondary
@@ -1170,6 +1170,7 @@ ORCA:
 	Aircraft:
 		TurnSpeed: 4
 		Speed: 120
+		InitialFacing: 224
 	Rearmable:
 		RearmActors: hpad
 		AmmoPools: primary, secondary
@@ -1181,22 +1182,26 @@ ORCA:
 		Range: 0c0
 		Type: GroundPosition
 	Armament@PRIMARY:
-		Weapon: Rocket
+		Name: primary
+		Weapon: RocketBurstGround
 		LocalOffset: 427,-171,-213, 427,171,-213
 		PauseOnCondition: !ammo
 		RequiresCondition: !PUTSUXEnabled
 	Armament@SECONDARY:
-		Weapon: Rocket
+		Name: secondary
+		Weapon: RocketBurstAir
 		LocalOffset: 427,-171,-213, 427,171,-213
 		PauseOnCondition: !ammo
 		RequiresCondition: !PUTSUXEnabled
 	Armament@PUTSUX:
 		RequiresCondition: PUTSUXEnabled
 		Weapon: Laser
+		Name: tertiary
 	AttackCharges:
 		RequiresCondition: PUTSUXEnabled
 		ChargeLevel: 50
 		ChargingCondition: charging
+		Armaments: tertiary 
 	AmbientSound:
 		RequiresCondition: charging
 		SoundFiles: obelpowr.aud

--- a/mods/tdo/rules/weapons.yaml
+++ b/mods/tdo/rules/weapons.yaml
@@ -157,6 +157,16 @@ Rocket:
 		ImpactSounds: xplos.aud
 		ImpactActors: false
 		ValidTargets: Air
+RocketBurstGround:
+	Inherits: Rocket
+	Burst: 2
+	BurstDelays: 10
+	ValidTargets: Ground
+RocketBurstAir:
+	Inherits: Rocket
+	Burst: 2
+	BurstDelays: 10
+	ValidTargets: Air
 
 # Infantry flamethrower
 InfantryFlamer:


### PR DESCRIPTION
closes #79
closes #37
closes #80
closes #88
closes #92

Fixes the following:
Apache and Orca now turn to land.
FreeActor trait now waits for helipad to finish its build animation before it spawns an aircraft.
FreeActor Trait can be turned off or on for helipads in the lobby.
Build Duration for helipad is now faster.
Orca now gets back to helipad to reload.
Orca weapons now fire in correct burst.
Newly trained aircraft units will arrive from map edge if all helipads are occupied.
